### PR TITLE
feat: bump plugin-cloud and payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "generate:graphQLSchema": "cross-env PAYLOAD_CONFIG_PATH=src/payload.config.ts payload generate:graphQLSchema"
   },
   "dependencies": {
-    "@payloadcms/plugin-cloud": "^0.0.10",
+    "@payloadcms/plugin-cloud": "^2.0.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "payload": "^1.7.2"
+    "payload": "^1.8.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,10 +1431,10 @@
     "@monaco-editor/loader" "^1.3.2"
     prop-types "^15.7.2"
 
-"@payloadcms/plugin-cloud@^0.0.10":
-  version "0.0.10"
-  resolved "https://registry.npmjs.org/@payloadcms/plugin-cloud/-/plugin-cloud-0.0.10.tgz#410e31db7457681e262be2873efdeb4c704b4293"
-  integrity sha512-ektfntigEImbLrRQszrB5fHI5AFx7W9hcqEwQ89lCliiV5YJyFDAhHjaqUnKjPWpNaOnhiOMTV84rjHgdds5hA==
+"@payloadcms/plugin-cloud@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@payloadcms/plugin-cloud/-/plugin-cloud-2.0.0.tgz#36a468e2effb1ff722078d7a7cd5f7cdad585941"
+  integrity sha512-fSBi9M3ZodoFX7K7MARSy9bS4rfXqqlRith0t/5IJ23exiXVKUBxgBSjEosJIFiu9gMwWsOK25RKKC8fQrbKmQ==
   dependencies:
     "@aws-sdk/client-cognito-identity" "^3.289.0"
     "@aws-sdk/client-s3" "^3.142.0"
@@ -5043,10 +5043,10 @@ pause@0.0.1:
   resolved "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
   integrity sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==
 
-payload@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/payload/-/payload-1.7.2.tgz#22aeb42871b1f09279382db9731724c697f44460"
-  integrity sha512-577DgrstocvKlnBo5ZgXEoH65qtoxP7HozgpgsFqAAgxCxudJ1zlnAAvce5usFxYdkOg6Yj1ezkq2ttLJeZbxA==
+payload@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.npmjs.org/payload/-/payload-1.8.2.tgz#94edff09f1580aa6dc28b41210244229303e1435"
+  integrity sha512-Bk7nDGdaQAhMIX7J9S+FkbLoZ+PNVrmwAg84RAj9Q7JyBeHHmJyDSTaGVenzXjWpch5bbMEd9nNdezpSalmZeg==
   dependencies:
     "@date-io/date-fns" "^2.16.0"
     "@dnd-kit/core" "^6.0.7"
@@ -5146,7 +5146,7 @@ payload@^1.7.2:
     slate-react "^0.92.0"
     style-loader "^2.0.0"
     swc-loader "^0.2.3"
-    swc-minify-webpack-plugin "^1.0.1"
+    swc-minify-webpack-plugin "^2.1.0"
     terser-webpack-plugin "^5.3.6"
     ts-essentials "^7.0.3"
     url-loader "^4.1.1"
@@ -6758,10 +6758,10 @@ swc-loader@^0.2.3:
   resolved "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.3.tgz#6792f1c2e4c9ae9bf9b933b3e010210e270c186d"
   integrity sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==
 
-swc-minify-webpack-plugin@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/swc-minify-webpack-plugin/-/swc-minify-webpack-plugin-1.1.2.tgz#4b8c97b005ab2bf1e993f9a0d38903227cc198d8"
-  integrity sha512-4GP6FlHsGZ8fA23OfEwSrGHOsAgYed/mCWlQmom7ocdd2AhHJsGNkHXsctjsKVfREIPcOdjZmim4ljkigz3EMw==
+swc-minify-webpack-plugin@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/swc-minify-webpack-plugin/-/swc-minify-webpack-plugin-2.1.0.tgz#35f975595d2e090064f34cb57f4ac4fd98a67eaa"
+  integrity sha512-v4B+Wcr84q58w2uALmjdTmOKyoF0pWY1xoGzy5vMibuQXQ0dHXlTmhodfu1NCiOISkqMf3T10nFmFQutBLw/vA==
 
 tabbable@^5.3.3:
   version "5.3.3"


### PR DESCRIPTION
Upgrade to latest payload and latest [plugin-cloud](https://www.npmjs.com/package/@payloadcms/plugin-cloud) 2.0, which includes email capability.